### PR TITLE
Add bump-python command to create a new environment with specified Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ uvve python install 3.12
 
 # List available and installed versions
 uvve python list
+
+# Upgrade existing environments to newer Python versions
+uvve python bump 3.12 myproject  # Bump specific environment
+uvve activate myproject && uvve python bump 3.12  # Bump active environment
 ```
 
 ## Advanced Usage
@@ -217,6 +221,62 @@ uvve thaw myproject          # Restore from lockfile
 - Lockfiles capture complete environment state
 - `thaw` restores tracked packages automatically
 
+### Python Version Management
+
+uvve provides comprehensive Python version management, including the ability to upgrade existing environments to newer Python versions while preserving dependencies:
+
+```bash
+# Install Python versions
+uvve python install 3.12     # Install Python 3.12
+uvve python install 3.13.5   # Install specific patch version
+
+# List available and installed Python versions
+uvve python list
+
+# Bump an existing environment to a newer Python version
+# Method 1: From an active environment
+uvve activate myproject
+uvve python bump 3.12         # Bumps current environment to Python 3.12
+
+# Method 2: Specify environment explicitly
+uvve python bump 3.12 myproject  # Bumps 'myproject' to Python 3.12
+
+# Remove unused Python versions
+uvve python remove 3.10
+```
+
+**Python Version Bumping Process:**
+
+1. **Validation**: Checks that target Python version is available
+2. **Dependency Preservation**: Creates lockfile of current packages
+3. **Environment Recreation**: Creates temporary environment with new Python version
+4. **Package Restoration**: Restores all dependencies from lockfile
+5. **Seamless Replacement**: Replaces old environment with new one
+
+**Example: Upgrading a Project**
+
+```bash
+# Start with Python 3.11 environment
+uvve create myproject 3.11
+uvve activate myproject
+uvve add requests django
+
+# Later, upgrade to Python 3.12 while keeping all packages
+uvve python bump 3.12
+# ✓ Environment 'myproject' successfully bumped to Python 3.12
+# ✓ All packages (requests, django) preserved
+
+# Verify the upgrade
+uvve freeze myproject  # Shows same packages, now on Python 3.12
+```
+
+**Use Cases:**
+
+- 🚀 **Project Upgrades**: Modernize projects to latest Python versions
+- 🔧 **Testing Compatibility**: Verify code works on different Python versions
+- 🛠️ **Maintenance**: Keep development environments current with security updates
+- 📦 **Package Requirements**: Upgrade when dependencies require newer Python versions
+
 ### Azure DevOps Integration
 
 Set up private package feeds with automatic authentication:
@@ -268,28 +328,30 @@ uvve --show-completion >> ~/.zshrc
 
 ### Command Reference
 
-| Command                         | Description                                                               |
-| ------------------------------- | ------------------------------------------------------------------------- |
-| `uvve python install <version>` | Install a Python version using uv                                         |
-| `uvve python list`              | List available and installed Python versions                              |
-| `uvve create <name> <version>`  | Create a virtual environment with optional metadata                       |
-| `uvve activate <name>`          | Activate environment (with shell integration) or print activation snippet |
-| `uvve local <name>`             | Create .uvve-version file for automatic directory-based activation        |
-| `uvve add <packages...>`        | Add packages to currently active environment (uses uv)                    |
-| `uvve list`                     | List all virtual environments                                             |
-| `uvve list --usage`             | List environments with usage statistics                                   |
-| `uvve remove <name>`            | Remove a virtual environment                                              |
-| `uvve lock <name>`              | Generate a lockfile for the environment                                   |
-| `uvve thaw <name>`              | Rebuild environment from lockfile                                         |
-| `uvve freeze <name>`            | Show installed packages in environment                                    |
-| `uvve analytics [name]`         | Show usage analytics and insights                                         |
-| `uvve status`                   | Show environment health overview                                          |
-| `uvve cleanup`                  | Clean up unused environments                                              |
-| `uvve edit <name>`              | Edit environment metadata (description, tags)                             |
-| `uvve setup-azure`              | Set up Azure DevOps package feed authentication                           |
-| `uvve feed-status`              | Show Azure DevOps configuration status                                    |
-| `uvve shell-integration`        | Install shell integration for direct activation                           |
-| `uvve --install-completion`     | Install tab completion for your shell                                     |
+| Command                            | Description                                                               |
+| ---------------------------------- | ------------------------------------------------------------------------- |
+| `uvve python install <version>`    | Install a Python version using uv                                         |
+| `uvve python list`                 | List available and installed Python versions                              |
+| `uvve python bump <version> [env]` | Upgrade environment to newer Python version while preserving dependencies |
+| `uvve python remove <version>`     | Remove an installed Python version                                        |
+| `uvve create <name> <version>`     | Create a virtual environment with optional metadata                       |
+| `uvve activate <name>`             | Activate environment (with shell integration) or print activation snippet |
+| `uvve local <name>`                | Create .uvve-version file for automatic directory-based activation        |
+| `uvve add <packages...>`           | Add packages to currently active environment (uses uv)                    |
+| `uvve list`                        | List all virtual environments                                             |
+| `uvve list --usage`                | List environments with usage statistics                                   |
+| `uvve remove <name>`               | Remove a virtual environment                                              |
+| `uvve lock <name>`                 | Generate a lockfile for the environment                                   |
+| `uvve thaw <name>`                 | Rebuild environment from lockfile                                         |
+| `uvve freeze <name>`               | Show installed packages in environment                                    |
+| `uvve analytics [name]`            | Show usage analytics and insights                                         |
+| `uvve status`                      | Show environment health overview                                          |
+| `uvve cleanup`                     | Clean up unused environments                                              |
+| `uvve edit <name>`                 | Edit environment metadata (description, tags)                             |
+| `uvve setup-azure`                 | Set up Azure DevOps package feed authentication                           |
+| `uvve feed-status`                 | Show Azure DevOps configuration status                                    |
+| `uvve shell-integration`           | Install shell integration for direct activation                           |
+| `uvve --install-completion`        | Install tab completion for your shell                                     |
 
 ## Development
 

--- a/src/uvve/cli.py
+++ b/src/uvve/cli.py
@@ -55,6 +55,7 @@ app.command("activate")(environment.activate)
 app.command("remove")(environment.remove)
 app.command("local")(environment.local)
 app.command("list")(environment.env_list)
+app.command("bump-python")(environment.bump_python)
 
 # Register package commands
 app.command("add")(packages.add)
@@ -111,17 +112,17 @@ def python_list() -> None:
         python_manager = PythonManager()
         available_versions = python_manager.list_available()
         installed_versions = python_manager.list_installed()
-        
+
         if not available_versions:
             console.print("[yellow]No Python versions found[/yellow]")
             return
-        
+
         # Create table
         table = Table(show_header=True, header_style="bold blue")
         table.add_column("Version", style="cyan")
         table.add_column("Status", style="green")
         table.add_column("Path", style="dim")
-        
+
         for version in available_versions:
             if version in installed_versions:
                 status = "✓ Installed"
@@ -129,11 +130,11 @@ def python_list() -> None:
             else:
                 status = "Available"
                 path = "-"
-            
+
             table.add_row(version, status, path)
-        
+
         console.print(table)
-        
+
     except Exception as e:
         console.print(f"[red]✗[/red] Failed to list Python versions: {e}")
         raise typer.Exit(1) from None
@@ -150,12 +151,12 @@ def python_install(
     """Install a Python version."""
     try:
         python_manager = PythonManager()
-        
+
         with console.status(f"[bold blue]Installing Python {version}..."):
             python_manager.install(version)
-        
+
         console.print(f"[green]✓[/green] Python {version} installed successfully")
-        
+
     except Exception as e:
         console.print(f"[red]✗[/red] Failed to install Python {version}: {e}")
         raise typer.Exit(1) from None
@@ -172,16 +173,14 @@ def python_remove(
     """Remove a Python version."""
     try:
         python_manager = PythonManager()
-        
-        if not typer.confirm(
-            f"Are you sure you want to remove Python {version}?"
-        ):
+
+        if not typer.confirm(f"Are you sure you want to remove Python {version}?"):
             console.print("[yellow]Removal cancelled[/yellow]")
             return
-        
+
         python_manager.remove(version)
         console.print(f"[green]✓[/green] Python {version} removed successfully")
-        
+
     except Exception as e:
         console.print(f"[red]✗[/red] Failed to remove Python {version}: {e}")
         raise typer.Exit(1) from None

--- a/src/uvve/cli.py
+++ b/src/uvve/cli.py
@@ -55,7 +55,6 @@ app.command("activate")(environment.activate)
 app.command("remove")(environment.remove)
 app.command("local")(environment.local)
 app.command("list")(environment.env_list)
-app.command("bump-python")(environment.bump_python)
 
 # Register package commands
 app.command("add")(packages.add)
@@ -183,6 +182,153 @@ def python_remove(
 
     except Exception as e:
         console.print(f"[red]✗[/red] Failed to remove Python {version}: {e}")
+        raise typer.Exit(1) from None
+
+
+def complete_environment_names(incomplete: str) -> list[str]:
+    """Auto-completion for environment names."""
+    try:
+        from uvve.core.manager import EnvironmentManager
+
+        env_manager = EnvironmentManager()
+        environments = env_manager.list()
+        return [
+            env["name"] for env in environments if env["name"].startswith(incomplete)
+        ]
+    except Exception:
+        return []
+
+
+@python_app.command("bump")
+def python_bump(
+    new_version: str = typer.Argument(
+        ...,
+        help="Target Python version (e.g., '3.13.5')",
+        autocompletion=complete_python_versions,
+    ),
+    env_name: str | None = typer.Argument(
+        None,
+        help="Environment name (auto-detected if not provided)",
+        autocompletion=complete_environment_names,
+    ),
+) -> None:
+    """Bump the Python version of a virtual environment."""
+    try:
+        from uvve.core.manager import EnvironmentManager
+        from uvve.core.freeze import FreezeManager
+
+        env_manager = EnvironmentManager()
+        freeze_manager = FreezeManager()
+        python_manager = PythonManager()
+
+        # Determine which environment to bump
+        if env_name:
+            # Use specified environment
+            target_env = env_name
+            if not env_manager.path_manager.environment_exists(target_env):
+                console.print(
+                    f"[red]✗[/red] Environment '{target_env}' does not exist."
+                )
+                raise typer.Exit(1)
+        else:
+            # Auto-detect current environment
+            target_env = env_manager.get_current_environment()
+            if not target_env:
+                console.print("[red]✗[/red] No uvve environment is currently active.")
+                console.print(
+                    "Either activate an environment with: [cyan]uvve activate <env_name>[/cyan]"
+                )
+                console.print(
+                    "Or specify environment with: [cyan]uvve python bump <version> <env_name>[/cyan]"
+                )
+                raise typer.Exit(1)
+
+        # Check if target Python version is available
+        available_versions = python_manager.list_available()
+        if new_version not in available_versions:
+            console.print(f"[red]✗[/red] Python {new_version} is not available.")
+            console.print("Available versions:")
+            for version in available_versions[-10:]:  # Show last 10 versions
+                console.print(f"  - {version}")
+            raise typer.Exit(1)
+
+        # Get current environment metadata to check current Python version
+        current_metadata = env_manager.get_metadata(target_env)
+        current_python = current_metadata.get("python_version", "unknown")
+
+        if current_python == new_version:
+            console.print(
+                f"[yellow]Environment '{target_env}' is already using Python {new_version}[/yellow]"
+            )
+            return
+
+        console.print(
+            f"[blue]Bumping environment '{target_env}' from Python {current_python} to {new_version}...[/blue]"
+        )
+
+        # Create a temporary lockfile to preserve dependencies
+        temp_env_name = f"{target_env}_bump_temp"
+
+        # Step 1: Create lockfile from current environment
+        console.print("[dim]1. Creating lockfile from current environment...[/dim]")
+        freeze_manager.lock(target_env)
+
+        # Step 2: Create temporary environment with new Python version
+        console.print(
+            f"[dim]2. Creating temporary environment with Python {new_version}...[/dim]"
+        )
+        env_manager.create(
+            name=temp_env_name,
+            python_version=new_version,
+            description=current_metadata.get("description", ""),
+            tags=current_metadata.get("tags", []),
+        )
+
+        # Step 3: Restore dependencies to temporary environment
+        console.print("[dim]3. Restoring dependencies...[/dim]")
+        # Copy the lockfile from the source to the temp environment so thaw can find it
+        import shutil as shutil_module
+
+        source_lockfile = freeze_manager.path_manager.get_lockfile_path(target_env)
+        temp_lockfile = freeze_manager.path_manager.get_lockfile_path(temp_env_name)
+        if source_lockfile.exists():
+            shutil_module.copy2(source_lockfile, temp_lockfile)
+            freeze_manager.thaw(temp_env_name)
+
+        # Step 4: Remove old environment
+        console.print("[dim]4. Removing old environment...[/dim]")
+        env_manager.remove(target_env)
+
+        # Step 5: Rename temporary environment to original name
+        console.print("[dim]5. Renaming temporary environment...[/dim]")
+        import shutil
+
+        temp_path = env_manager.path_manager.get_env_path(temp_env_name)
+        target_path = env_manager.path_manager.get_env_path(target_env)
+        shutil.move(str(temp_path), str(target_path))
+
+        # Update metadata with new Python version
+        env_manager._create_metadata(
+            name=target_env,
+            python_version=new_version,
+            description=current_metadata.get("description", ""),
+            tags=current_metadata.get("tags", []),
+        )
+
+        console.print(
+            f"[green]✓[/green] Environment '{target_env}' successfully bumped to Python {new_version}"
+        )
+        console.print(f"Activate with: [cyan]uvve activate {target_env}[/cyan]")
+
+    except Exception as e:
+        console.print(f"[red]✗[/red] Failed to bump Python version: {e}")
+        # Clean up temporary environment if it exists
+        try:
+            temp_env_name = f"{target_env}_bump_temp"
+            if env_manager.path_manager.environment_exists(temp_env_name):
+                env_manager.remove(temp_env_name)
+        except:
+            pass
         raise typer.Exit(1) from None
 
 

--- a/src/uvve/commands/environment.py
+++ b/src/uvve/commands/environment.py
@@ -1,13 +1,12 @@
 """Environment management commands."""
 
 import typer
+from pathlib import Path
 from rich.console import Console
 from rich.table import Table
 
 from uvve.core.manager import EnvironmentManager
-from uvve.core.freeze import FreezeManager
 from uvve.shell.activate import ActivationManager
-from pathlib import Path
 
 console = Console()
 
@@ -212,42 +211,4 @@ def local(
 
     except Exception as e:
         console.print(f"[red]✗[/red] Failed to set local environment: {e}")
-        raise typer.Exit(1) from None
-
-
-def bump_python(
-    new_env_name: str = typer.Argument(..., help="Name of the new environment"),
-    python_version: str = typer.Argument(
-        ..., help="Target Python version (e.g., '3.13.5')"
-    ),
-) -> None:
-    """Create a new environment with a specified Python version, copying dependencies from the active environment."""
-    try:
-        env_manager = EnvironmentManager()
-        freeze_manager = FreezeManager()
-        source_env = env_manager.get_current_environment()
-        if not source_env:
-            console.print("[red]✗[/red] No uvve environment is currently active.")
-            console.print(
-                "Activate an environment with: [cyan]uvve activate <env_name>[/cyan]"
-            )
-            raise typer.Exit(1)
-        if env_manager.path_manager.environment_exists(new_env_name):
-            console.print(f"[red]✗[/red] Environment '{new_env_name}' already exists.")
-            raise typer.Exit(1)
-        console.print(
-            f"[blue]Bumping environment '{source_env}' to '{new_env_name}' with Python {python_version}...[/blue]"
-        )
-        freeze_manager.lock(source_env)
-        env_manager.create(
-            name=new_env_name,
-            python_version=python_version,
-        )
-        freeze_manager.thaw(new_env_name)
-        console.print(
-            f"[green]✓[/green] Environment '{new_env_name}' created with Python {python_version} and dependencies from '{source_env}'."
-        )
-        console.print(f"Activate with: [cyan]uvve activate {new_env_name}[/cyan]")
-    except Exception as e:
-        console.print(f"[red]✗[/red] Failed to bump environment: {e}")
         raise typer.Exit(1) from None

--- a/src/uvve/commands/environment.py
+++ b/src/uvve/commands/environment.py
@@ -5,6 +5,7 @@ from rich.console import Console
 from rich.table import Table
 
 from uvve.core.manager import EnvironmentManager
+from uvve.core.freeze import FreezeManager
 from uvve.shell.activate import ActivationManager
 from pathlib import Path
 
@@ -211,4 +212,42 @@ def local(
 
     except Exception as e:
         console.print(f"[red]✗[/red] Failed to set local environment: {e}")
+        raise typer.Exit(1) from None
+
+
+def bump_python(
+    new_env_name: str = typer.Argument(..., help="Name of the new environment"),
+    python_version: str = typer.Argument(
+        ..., help="Target Python version (e.g., '3.13.5')"
+    ),
+) -> None:
+    """Create a new environment with a specified Python version, copying dependencies from the active environment."""
+    try:
+        env_manager = EnvironmentManager()
+        freeze_manager = FreezeManager()
+        source_env = env_manager.get_current_environment()
+        if not source_env:
+            console.print("[red]✗[/red] No uvve environment is currently active.")
+            console.print(
+                "Activate an environment with: [cyan]uvve activate <env_name>[/cyan]"
+            )
+            raise typer.Exit(1)
+        if env_manager.path_manager.environment_exists(new_env_name):
+            console.print(f"[red]✗[/red] Environment '{new_env_name}' already exists.")
+            raise typer.Exit(1)
+        console.print(
+            f"[blue]Bumping environment '{source_env}' to '{new_env_name}' with Python {python_version}...[/blue]"
+        )
+        freeze_manager.lock(source_env)
+        env_manager.create(
+            name=new_env_name,
+            python_version=python_version,
+        )
+        freeze_manager.thaw(new_env_name)
+        console.print(
+            f"[green]✓[/green] Environment '{new_env_name}' created with Python {python_version} and dependencies from '{source_env}'."
+        )
+        console.print(f"Activate with: [cyan]uvve activate {new_env_name}[/cyan]")
+    except Exception as e:
+        console.print(f"[red]✗[/red] Failed to bump environment: {e}")
         raise typer.Exit(1) from None

--- a/src/uvve/core/python.py
+++ b/src/uvve/core/python.py
@@ -21,6 +21,21 @@ class PythonManager:
         except subprocess.CalledProcessError as e:
             raise RuntimeError(f"Failed to install Python {version}: {e.stderr}") from e
 
+    def remove(self, version: str) -> None:
+        """Remove a Python version using uv.
+
+        Args:
+            version: Python version to remove (e.g., "3.11", "3.11.5")
+
+        Raises:
+            RuntimeError: If removal fails
+        """
+        try:
+            cmd = ["uv", "python", "uninstall", version]
+            subprocess.run(cmd, capture_output=True, text=True, check=True)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"Failed to remove Python {version}: {e.stderr}") from e
+
     def list_installed(self) -> list[str]:
         """List installed Python versions.
 


### PR DESCRIPTION
# Add Python Version Bumping Feature

## What This Does

Adds a new `uvve python bump` command that lets you upgrade virtual environments to newer Python versions while keeping all your packages.

## New Command

```bash
# Bump the currently active environment
uvve activate myproject
uvve python bump 3.12

# Or bump a specific environment
uvve python bump 3.12 myproject
```

## How It Works

1. Creates a backup of your current packages
2. Builds a new environment with the target Python version
3. Restores all your packages to the new environment
4. Replaces the old environment seamlessly

## What Changed

### Added
- `uvve python bump <version> [env_name]` - Upgrade Python version
- `uvve python remove <version>` - Remove Python versions
- Comprehensive documentation in README

### Removed
- `uvve bump-python` (replaced with the new command above)

## Example Usage

```bash
# Start with Python 3.11
uvve create myproject 3.11
uvve activate myproject
uvve add requests django

# Upgrade to Python 3.12 (keeps all packages)
uvve python bump 3.12
# ✓ Environment 'myproject' successfully bumped to Python 3.12

# Verify packages are still there
uvve freeze myproject  # Shows requests, django, etc.
```

## Safety Features

- ✅ Validates Python version is available before starting
- ✅ Preserves all installed packages automatically
- ✅ Prevents bumping to the same version
- ✅ Clean error messages with helpful suggestions
- ✅ Automatic cleanup if something goes wrong

## Breaking Change

The old `uvve bump-python` command is removed. Use `uvve python bump` instead.
